### PR TITLE
1.取消使用lua内置的字符串串切割方式，使用openresty自带的ngx.re.split方法，提高性能和代码阅读性 2.注释一段无用的代码

### DIFF
--- a/lua/tools.lua
+++ b/lua/tools.lua
@@ -1,11 +1,25 @@
 module("tools", package.seeall)
+local ngx_re = require "ngx.re"
+
 function split(s, p)
     -- 字符串切割
     local rt = {}
-    string.gsub(s, '[^' .. p .. ']+', function(w)
-        rt[#rt + 1] = w
-        --table.insert(rt, w)
-    end )
+
+    -- 对问号分割做转义
+    if p == "?" then
+        p = "\\?"
+    end
+    
+    local res = ngx_re.split(s, p)
+    if res then
+        if res[1] == "" then
+            table.remove(res, 1)
+        end
+        rt = res
+    else
+        table.insert(rt, 1, s)
+    end
+
     return rt
 end
 

--- a/lua/upstream.lua
+++ b/lua/upstream.lua
@@ -21,7 +21,7 @@ function _M.set(real_new_uri)
 		for i, elem in ipairs(rewrite_conf[host]['rewrite_urls']) do
 			--local ret = tools.match(uri,elem['uri'])
 			--if ret then
-			local ret = tools.match('/'..svc_code,elem['uri'])
+			-- local ret = tools.match('/'..svc_code,elem['uri'])
 			if '/'..svc_code == elem['uri'] then
 				data [string.len(elem['uri'])] = elem['rewrite_upstream']
 			end


### PR DESCRIPTION
local ret = tools.match('/'..svc_code,elem['uri'])这行代码无用，可以取消掉。该函数内部使用了Lua自带的模式匹配，这不仅是出于性能方面的考虑(不能被 JIT，而且被编译过一次的模式也不会被缓存)，还因为 Lua 自带的正则是自成体系的，并非 PCRE 规范，这对于绝大部分开发者来说都是徒增烦恼。